### PR TITLE
TransformerMakeCommand namespace typo

### DIFF
--- a/src/Commands/TransformerMakeCommand.php
+++ b/src/Commands/TransformerMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yajra\Datatables\Commands;
+namespace Yajra\DataTables\Commands;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;


### PR DESCRIPTION
Hello, my package:discover fails (with composer classmap-authoritative option) because where is type in namespace