### PR TITLE
Allow using closures as transformer (#1)

### DIFF
--- a/src/Transformers/FractalTransformer.php
+++ b/src/Transformers/FractalTransformer.php
@@ -82,7 +82,7 @@ class FractalTransformer
      */
     protected function createTransformer($transformer)
     {
-        if ($transformer instanceof TransformerAbstract) {
+        if ($transformer instanceof TransformerAbstract || $transformer instanceof \Closure) {
             return $transformer;
         }
 


### PR DESCRIPTION
Original Fractal package allows closures as transformers (https://fractal.thephpleague.com/transformers/)
so it would be good and useful to leave that feature
SO it for example will allow folks to transform the data using Laravel API Resource like this
```
return DataTables::eloquent($query)
            ->setTransformer(function ($item){
                return Resource::make($item)->resolve();
            })
            ->make();
```
Also, if you accept this PR, would be probably nice to update 'datatables' docs chapter ['Response > Fractal Transformer'](http://yajrabox.com/docs/laravel-datatables/master/response-fractal)

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-fractal/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
