### PR TITLE
fix: Change request method from `get` to `input` for includes

### DIFF
--- a/src/FractalServiceProvider.php
+++ b/src/FractalServiceProvider.php
@@ -68,8 +68,8 @@ class FractalServiceProvider extends ServiceProvider
             $request = $this->app['request'];
 
             $includesKey = $config->get('datatables-fractal.includes', 'include');
-            if ($request->get($includesKey)) {
-                $fractal->parseIncludes($request->get($includesKey));
+            if ($request->input($includesKey)) {
+                $fractal->parseIncludes($request->input($includesKey));
             }
 
             $serializer = $config->get('datatables-fractal.serializer', DataArraySerializer::class);


### PR DESCRIPTION
The reason for this change is because of a deprecation: `Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead.`

https://symfony.com/blog/new-in-symfony-7-4-request-class-improvements#deprecated-the-get-method

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-datatables-fractal/blob/master/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
